### PR TITLE
Store uploaded_documents in a dedicated docker volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,11 @@ services:
       - DBHOST=mongo
       - DATABASE_NAME=uwazi_development
       - ELASTICSEARCH_URL=http://elasticsearch:9200
+      - UPLOADS_FOLDER=/data/uploaded_documents
+      # - LOGS_DIR=/path/to/log
       - IS_FIRST_RUN=${IS_FIRST_RUN:-false}
+    volumes:
+      - uwazi_uploaded_documents:/data/uploaded_documents
     depends_on:
       - elasticsearch
       - mongo
@@ -74,6 +78,8 @@ services:
       - 52000:3000
 
 volumes:
+  uwazi_uploaded_documents:
+    driver: local
   esdata1:
     driver: local
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       # - LOGS_DIR=/path/to/log
       - IS_FIRST_RUN=${IS_FIRST_RUN:-false}
     volumes:
-      - uwazi_uploaded_documents:/data/uploaded_documents
+      - uploaded_documents:/data/uploaded_documents
     depends_on:
       - elasticsearch
       - mongo
@@ -32,7 +32,7 @@ services:
         soft: -1
         hard: -1
     volumes:
-      - esdata1:/usr/share/elasticsearch/data
+      - elasticsearch_data1:/usr/share/elasticsearch/data
     # TODO: close these ports (fititnt, 2018-04-14 10:22 BRT)
     ports:
       - 9200:9200
@@ -78,9 +78,9 @@ services:
       - 52000:3000
 
 volumes:
-  uwazi_uploaded_documents:
+  uploaded_documents:
     driver: local
-  esdata1:
+  elasticsearch_data1:
     driver: local
 
 

--- a/uninstall.md
+++ b/uninstall.md
@@ -18,6 +18,7 @@ programs and all content created.
 ```bash
 
 # Remove containers, networks and volumes created by uwazi-docker docker-compose up
+## WARNING! THIS WILL DELETE THE DATABASE AND DOCUMENTS!!!
 docker-compose down -v --rmi all --remove-orphans
 
 # data/ folder can contain additional files. If you are using linux, depending


### PR DESCRIPTION
As reported on #20, the documents by default where on the docker container instead of a dedicated volume or at least a folder on the host.

This PR is to make a dedicated docker volume for uploaded_documents