### PR TITLE
Updated server-side dependencies (year 2023) and use `production` tag as baseline for install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
   dh-autoreconf \
   git \
   libpng-dev \
+  libcurl3 \
+  openssl \
   poppler-utils
 
 RUN curl -fsSL https://pgp.mongodb.com/server-4.2.asc | \
@@ -17,7 +19,8 @@ RUN curl -fsSL https://pgp.mongodb.com/server-4.2.asc | \
 
 RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-4.2.gpg ] http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.2 main" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list
 RUN apt-get update
-RUN apt-get install -y mongodb-org-shell mongodb-org-tools 
+# RUN apt-get install -y mongodb-org-shell mongodb-org-tools 
+RUN apt-get install -y mongodb-org-tools 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ LABEL maintainer="Emerson Rocha <rocha@ieee.org>"
 
 ARG UWAZI_GIT_RELEASE_REF=production
 
-# see https://github.com/nodejs/docker-node#how-to-use-this-image
-
 ## Install common software
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
   bzip2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:18-bullseye
 LABEL maintainer="Emerson Rocha <rocha@ieee.org>"
 
+ARG UWAZI_GIT_RELEASE_REF=production
+
 # see https://github.com/nodejs/docker-node#how-to-use-this-image
 
 ## Install common software
@@ -26,7 +28,7 @@ RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg] http://rep
   && apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-RUN git clone -b production --single-branch --depth=1 https://github.com/huridocs/uwazi.git /home/node/uwazi/ \
+RUN git clone -b "$UWAZI_GIT_RELEASE_REF" --single-branch --depth=1 https://github.com/huridocs/uwazi.git /home/node/uwazi/ \
   && chown node:node -R /home/node/uwazi/ \
   && cd /home/node/uwazi/ \
   && yarn install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,33 +9,23 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
   dh-autoreconf \
   git \
   libpng-dev \
-  libcurl3 \
-  openssl \
+  gnupg \
   poppler-utils
-
-RUN curl -fsSL https://pgp.mongodb.com/server-4.2.asc | \
-   gpg -o /usr/share/keyrings/mongodb-server-4.2.gpg \
-   --dearmor
-
-RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-4.2.gpg ] http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.2 main" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list
-RUN apt-get update
-# RUN apt-get install -y mongodb-org-shell mongodb-org-tools 
-RUN apt-get install -y mongodb-org-tools 
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 
 # Install mongo & mongorestore (this is used only for database initialization, not on runtime)
 # So much space need, see 'After this operation, 184 MB of additional disk space will be used.'
-# RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 20691EEC35216C63CAF66CE1656408E390CFB1F5 \
-#   && echo "deb http://repo.mongodb.org/apt/debian bullseye/mongodb-org/4.2 main" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list \
-# RUN echo "deb http://repo.mongodb.org/apt/debian bullseye/mongodb-org/4.2 main" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list \
-#   && apt-get update \
-#   && apt-get install -y mongodb-org-shell mongodb-org-tools \
-#   && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://pgp.mongodb.com/server-6.0.asc | \
+   gpg -o /usr/share/keyrings/mongodb-server-6.0.gpg \
+   --dearmor
 
-# ## Download Uwazi v1.4
-# RUN git clone -b v1.4 --single-branch --depth=1 https://github.com/huridocs/uwazi.git /home/node/uwazi/ \
-## Download Uwazi v1.4
+RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg] http://repo.mongodb.org/apt/debian bullseye/mongodb-org/6.0 main" \
+  | tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
+  && apt-get update \
+  && apt-get install -y mongodb-mongosh mongodb-org-tools \
+  && apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
 RUN git clone -b production --single-branch --depth=1 https://github.com/huridocs/uwazi.git /home/node/uwazi/ \
   && chown node:node -R /home/node/uwazi/ \
   && cd /home/node/uwazi/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-jessie
+FROM node:18-bullseye
 LABEL maintainer="Emerson Rocha <rocha@ieee.org>"
 
 # see https://github.com/nodejs/docker-node#how-to-use-this-image
@@ -11,16 +11,29 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
   libpng-dev \
   poppler-utils
 
+RUN curl -fsSL https://pgp.mongodb.com/server-4.2.asc | \
+   gpg -o /usr/share/keyrings/mongodb-server-4.2.gpg \
+   --dearmor
+
+RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-4.2.gpg ] http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.2 main" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list
+RUN apt-get update
+RUN apt-get install -y mongodb-org-shell mongodb-org-tools 
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+
 # Install mongo & mongorestore (this is used only for database initialization, not on runtime)
 # So much space need, see 'After this operation, 184 MB of additional disk space will be used.'
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5 \
-  && echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.6 main" | tee /etc/apt/sources.list.d/mongodb-org-3.6.list \
-  && apt-get update \
-  && apt-get install -y mongodb-org-shell mongodb-org-tools \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
+# RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 20691EEC35216C63CAF66CE1656408E390CFB1F5 \
+#   && echo "deb http://repo.mongodb.org/apt/debian bullseye/mongodb-org/4.2 main" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list \
+# RUN echo "deb http://repo.mongodb.org/apt/debian bullseye/mongodb-org/4.2 main" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list \
+#   && apt-get update \
+#   && apt-get install -y mongodb-org-shell mongodb-org-tools \
+#   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# ## Download Uwazi v1.4
+# RUN git clone -b v1.4 --single-branch --depth=1 https://github.com/huridocs/uwazi.git /home/node/uwazi/ \
 ## Download Uwazi v1.4
-RUN git clone -b v1.4 --single-branch --depth=1 https://github.com/huridocs/uwazi.git /home/node/uwazi/ \
+RUN git clone -b production --single-branch --depth=1 https://github.com/huridocs/uwazi.git /home/node/uwazi/ \
   && chown node:node -R /home/node/uwazi/ \
   && cd /home/node/uwazi/ \
   && yarn install \

--- a/README.md
+++ b/README.md
@@ -139,4 +139,13 @@ instead of Public Domain unlicense.
   - https://repo.mongodb.org/apt/debian/dists/bullseye/mongodb-org/
 
 
+# Refrech
+
+
+docker compose --file docker-compose.yml run -e IS_FIRST_RUN=true --rm uwazi
+
+# ...
+
+docker system prune --all
+
 -->

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker compose run -e IS_FIRST_RUN=true --rm uwazi # Install/Re-install from emp
 docker compose up -d uwazi # Run uwazi on background (automatic restart on reboot unless stopped)
 ```
 
-Open your browser at <http://localhost:3000/>. Initial user: _admin_, password: _admin_.
+Open your browser at <http://localhost:3000/>. Initial user: `admin`, password: `change this password now`.
 
 ### Basic docker commands
 
@@ -146,6 +146,7 @@ docker compose --file docker compose.yml run -e IS_FIRST_RUN=true --rm uwazi
 # (...)
 docker stop $(docker ps -a -q)
 docker system prune --all
+docker volume prune
 
 # debug containers
 docker ps

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ for building and sharing document collections.
 See also [History of Uwazi](https://github.com/huridocs/uwazi/wiki/History-of-Uwazi).
 
 ## Usage
-The uwazi-docker requires docker-compose installed. See
+The uwazi-docker requires docker compose installed. See
 [requirements](requirements.md). If you are a developer, can also check some
 advanced information on [development-instructions.md](development-instructions.md)
 and a draft of [production-instructions.md](production-instructions.md).
@@ -31,15 +31,15 @@ Run these commands on your terminal **only** the first time:
 ```bash
 git clone https://github.com/fititnt/uwazi-docker.git
 cd uwazi-docker
-docker-compose run -e IS_FIRST_RUN=true --rm uwazi # Install/Re-install from empty data
+docker compose run -e IS_FIRST_RUN=true --rm uwazi # Install/Re-install from empty data
 
 ```
-<!-- docker-compose run --rm uwazi-installer -->
+<!-- docker compose run --rm uwazi-installer -->
 
 ### Run
 
 ```bash
-docker-compose up -d uwazi # Run uwazi on background (automatic restart on reboot unless stopped)
+docker compose up -d uwazi # Run uwazi on background (automatic restart on reboot unless stopped)
 ```
 
 Open your browser at <http://localhost:3000/>. Initial user: _admin_, password: _admin_.
@@ -48,13 +48,13 @@ Open your browser at <http://localhost:3000/>. Initial user: _admin_, password: 
 
 ```bash
 # Stop all containers from this uwazi-docker and do not restart again until you explicit ask for it
-docker-compose stop
+docker compose stop
 
 # Using "-d" param to run uwazi and its dependencies on background
-docker-compose up -d uwazi
+docker compose up -d uwazi
 
 # No "-d" param, start uwazi, MongoDB & Elastic Search and see what is happening inside the containers
-docker-compose up uwazi
+docker compose up uwazi
 
 # See what containers are running now
 docker ps
@@ -66,10 +66,10 @@ docker volume ls
 docker volume ls | grep 'mongodb_data1\|uploaded_documents'
 
 # Want some GUI to see what is happening on MongoDB? Use nosqlclient
-docker-compose up -d mongo-gui-mongoclient
+docker compose up -d mongo-gui-mongoclient
 
 # Want some GUI to see what is happening on Elastic Search? Try Dejavu
-docker-compose up -d elasticsearch-gui-dejavu
+docker compose up -d elasticsearch-gui-dejavu
 ```
 
 ### Extra features
@@ -77,7 +77,7 @@ docker-compose up -d elasticsearch-gui-dejavu
 #### Want some GUI to see what is happening on MongoDB? Use nosqlclient
 
 ```bash
-docker-compose up -d mongo-gui-mongoclient
+docker compose up -d mongo-gui-mongoclient
 ```
 
 By default, uses <http://localhost:51000/>.
@@ -85,7 +85,7 @@ By default, uses <http://localhost:51000/>.
 #### Want some GUI to see what is happening on Elastic Search? Try Dejavu
 
 ```bash
-docker-compose up -d elasticsearch-gui-dejavu
+docker compose up -d elasticsearch-gui-dejavu
 ```
 
 By default, uses <http://localhost:52000/>.
@@ -110,14 +110,14 @@ instead of Public Domain unlicense.
 
 # Tests on Ubuntu 20.04 LTS
 
-    fititnt@bravo:/workspace/git/fititnt/uwazi-docker$ docker compose --file /workspace/git/fititnt/uwazi-docker/docker-compose.yml run -e IS_FIRST_RUN=true --rm uwazi
-    stat /workspace/git/fititnt/uwazi-docker/docker-compose.yml: no such file or directory
-    fititnt@bravo:/workspace/git/fititnt/uwazi-docker$ docker compose --file docker-compose.yml run -e IS_FIRST_RUN=true --rm uwazi
-    stat /var/lib/snapd/void/docker-compose.yml: no such file or directory
+    fititnt@bravo:/workspace/git/fititnt/uwazi-docker$ docker compose --file /workspace/git/fititnt/uwazi-docker/docker compose.yml run -e IS_FIRST_RUN=true --rm uwazi
+    stat /workspace/git/fititnt/uwazi-docker/docker compose.yml: no such file or directory
+    fititnt@bravo:/workspace/git/fititnt/uwazi-docker$ docker compose --file docker compose.yml run -e IS_FIRST_RUN=true --rm uwazi
+    stat /var/lib/snapd/void/docker compose.yml: no such file or directory
 
     fititnt@bravo:~/Downloads/uwazi-docker$ sudo su
     [sudo] password for fititnt: 
-    root@bravo:/home/fititnt/Downloads/uwazi-docker# docker compose --file docker-compose.yml run -e IS_FIRST_RUN=true --rm uwazi
+    root@bravo:/home/fititnt/Downloads/uwazi-docker# docker compose --file docker compose.yml run -e IS_FIRST_RUN=true --rm uwazi
 
     Logs
     (...)
@@ -142,10 +142,18 @@ instead of Public Domain unlicense.
 # Refrech
 
 
-docker compose --file docker-compose.yml run -e IS_FIRST_RUN=true --rm uwazi
-
-# ...
-
+docker compose --file docker compose.yml run -e IS_FIRST_RUN=true --rm uwazi
+# (...)
+docker stop $(docker ps -a -q)
 docker system prune --all
+
+# debug containers
+docker ps
+docker logs --tail 50 --follow --timestamps uwazi-docker-mongo-1
+docker logs --tail 50 --follow --timestamps uwazi-docker-elasticsearch-1
+
+
+###
+git clone -b production --single-branch --depth=1 https://github.com/huridocs/uwazi.git huridocs-uwazi-docker/
 
 -->

--- a/README.md
+++ b/README.md
@@ -129,4 +129,14 @@ instead of Public Domain unlicense.
     #0 4.000   404  Not Found
     (...)
 
+- Potential problems
+  - https://github.com/nodejs/docker-node/issues/1916
+  - https://github.com/nodejs/docker-node/issues/1918
+
+- EOL debian
+  - https://endoflife.date/debian
+- Mongo 4.2
+  - https://repo.mongodb.org/apt/debian/dists/bullseye/mongodb-org/
+
+
 -->

--- a/README.md
+++ b/README.md
@@ -34,15 +34,31 @@ cd uwazi-docker
 docker compose run -e IS_FIRST_RUN=true --rm uwazi # Install/Re-install from empty data
 
 ```
-<!-- docker compose run --rm uwazi-installer -->
+
+With very fast internet and disks, this step will take between 8 to 15 minutes.
 
 ### Run
 
 ```bash
-docker compose up -d uwazi # Run uwazi on background (automatic restart on reboot unless stopped)
+# Run uwazi on background (automatic restart on reboot unless stopped)
+docker compose up -d uwazi
 ```
 
 Open your browser at <http://localhost:3000/>. Initial user: `admin`, password: `change this password now`.
+
+#### `yarn migrate` and `yarn reindex`
+
+At installation step the `yarn migrate` and `yarn reindex` are always executed,
+however the database will be erased to a blank state.
+However, if for some you already have real data and not major database upgrade,
+in which MongoDB and ElasticSearch might need some minor custom steps outside of Uwazi control,
+this command will run once only the `yarn migrate` and `yarn reindex`.
+
+```bash
+docker compose run -e RUN_YARN_MIGRATE_REINDEX=true --rm uwazi
+```
+
+Just to be sure, if working with real data, **please backup the volumes first**.
 
 ### Basic docker commands
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ docker compose run -e IS_FIRST_RUN=true --rm uwazi # Install/Re-install from emp
 
 With very fast internet and disks, this step will take between 8 to 15 minutes.
 
+<details>
+<summary>(Advanced) All initialization options with default values</summary>
+
+Uwazi docker fetch data from git, and a very specific release (UWAZI_GIT_RELEASE_REF defaults to tag production, but this likely eventually will require upgrade uwazi-docker itself) and initialize with empty database (DB_INITIALIZATION_PATH, but you may want to change for a example test database, or even upstream might change path in the future).
+
+With this in mind, the default values might need updates (which in this case please open an issue and report the problem) but in the meantime you can just change the options.
+
+<pre>
+git clone https://github.com/fititnt/uwazi-docker.git
+cd uwazi-docker
+docker compose run -e IS_FIRST_RUN=true UWAZI_GIT_RELEASE_REF=production DB_INITIALIZATION_PATH=/home/node/uwazi/dump/uwazi_development --rm uwazi
+</pre>
+</details>
+
 ### Run
 
 ```bash

--- a/development-instructions.md
+++ b/development-instructions.md
@@ -44,21 +44,21 @@ tabs.
 
 ```bash
 # To run and see messages
-docker-compose up elasticsearch mongo
+docker compose up elasticsearch mongo
 
 # To run on background use -d param
-docker-compose up -d elasticsearch mongo
+docker compose up -d elasticsearch mongo
 
 # Stop all containers from uwazi-docker after they where not more need and
 # avoid they stay running even after you reboot your operational system
-docker-compose down
+docker compose down
 ```
 
 The following step is optional if you want to populate the databases not using
 uwazi-docker.
 
 ```bash
-docker-compose run -e IS_FIRST_RUN=true --rm uwazi
+docker compose run -e IS_FIRST_RUN=true --rm uwazi
 ```
 
 ## Create your own repository
@@ -143,17 +143,17 @@ local development machine. **9300/tcp** means the same container have the port
 ```bash
 
 # See log messages of Mongo and Elastic Search
-docker-compose logs -f mongo elasticsearch
+docker compose logs -f mongo elasticsearch
 
 # Want some GUI to see what is happening on MongoDB? Use nosqlclient
-docker-compose up -d mongo-gui-mongoclient
+docker compose up -d mongo-gui-mongoclient
 
 # Want some GUI to see what is happening on Elastic Search? Try Dejavu
-docker-compose up -d elasticsearch-gui-dejavu
+docker compose up -d elasticsearch-gui-dejavu
 ```
 ### Configure ports of Mongo and Elastic Search
 
-At this point, you have to edit the file [docker-compose.yml](docker-compose.yml)
+At this point, you have to edit the file [docker compose.yml](docker compose.yml)
 and edit the hardcored values.
 
 Protip: the most common error of using uwazi-docker with Uwazi a port is already

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - UPLOADS_FOLDER=/data/uploaded_documents
       # - LOGS_DIR=/path/to/log
       - IS_FIRST_RUN=${IS_FIRST_RUN:-false}
+      - UWAZI_RELEASE_TAG=${UWAZI_RELEASE_TAG:-production}
     volumes:
       - uploaded_documents:/data/uploaded_documents
     depends_on:
@@ -28,7 +29,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - xpack.security.enabled=false
+      # - xpack.security.enabled=false
     ulimits:
       memlock:
         soft: -1
@@ -55,12 +56,15 @@ services:
   mongo:
     # image: mongo:3.4
     # Based on https://github.com/huridocs/uwazi/releases/tag/1.123.2 . Please update this part in future
-    image: mongo:4.2
+    # image: mongo:4.2
+    # Using mongo 6.0 (not 4.2 as suggested by Uwazi 1.123.2) because mongo-shell on 4.2 don't run on Debian bullseye
+    image: mongo:6.0
     restart: unless-stopped
     volumes:
       # - ./data/mongo:/data/db
       - mongodb_data1:/data/db
-    command: mongod --smallfiles
+    command: mongod
+    # command: mongod --smallfiles
   # Don't publish unprotected mongod
   #  ports:
   #    - 27017:27017

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,9 @@ services:
       - UPLOADS_FOLDER=/data/uploaded_documents
       # - LOGS_DIR=/path/to/log
       - IS_FIRST_RUN=${IS_FIRST_RUN:-false}
-      - UWAZI_RELEASE_TAG=${UWAZI_RELEASE_TAG:-production}
+      - RUN_YARN_MIGRATE_REINDEX=${RUN_YARN_MIGRATE_REINDEX:-false}
+      - UWAZI_GIT_RELEASE_REF=${UWAZI_GIT_RELEASE_REF:-production}
+      - DB_INITIALIZATION_PATH=${DB_INITIALIZATION_PATH:-/home/node/uwazi/database/blank_state/uwazi_development}
     volumes:
       - uploaded_documents:/data/uploaded_documents
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,25 +20,43 @@ services:
       - elasticsearch
       - mongo
 
+  # elasticsearch:
+  #   # image: docker.elastic.co/elasticsearch/elasticsearch:5.5.3
+  #   # Based on https://github.com/huridocs/uwazi/releases/tag/1.123.2 . Please update this part in future
+  #   image: docker.elastic.co/elasticsearch/elasticsearch:7.17.6
+  #   restart: unless-stopped
+  #   # command: elasticsearch -Expack.security.enabled=false -Ecluster.name=docker-cluster -Ehttp.port=9200 -Ehttp.cors.allow-origin="http://localhost:51000" -Ehttp.cors.enabled=true -Ehttp.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization -Ehttp.cors.allow-credentials=true
+  #   command: elasticsearch -Expack.security.enabled=false -Ehttp.port=9200 -Ehttp.cors.allow-origin="http://localhost:51000" -Ehttp.cors.enabled=true -Ehttp.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization -Ehttp.cors.allow-credentials=true
+  #   environment:
+  #     # - cluster.name=docker-cluster
+  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+  #     # - xpack.security.enabled=false
+  #   ulimits:
+  #     memlock:
+  #       soft: -1
+  #       hard: -1
+  #   volumes:
+  #     - elasticsearch_data1:/usr/share/elasticsearch/data
+  #   # Close these ports. No unprotected elasticsearch should be published.
+  #   # ports:
+  #   #  - 9200:9200
+
   elasticsearch:
-    # image: docker.elastic.co/elasticsearch/elasticsearch:5.5.3
-    # Based on https://github.com/huridocs/uwazi/releases/tag/1.123.2 . Please update this part in future
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.6
-    restart: unless-stopped
-    command: elasticsearch -Expack.security.enabled=false -Ecluster.name=docker-cluster -Ehttp.port=9200 -Ehttp.cors.allow-origin="http://localhost:51000" -Ehttp.cors.enabled=true -Ehttp.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization -Ehttp.cors.allow-credentials=true
-    environment:
-      - cluster.name=docker-cluster
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      # - xpack.security.enabled=false
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
+    build:
+      context: .
+      dockerfile: elastic-icu-7.17.6.Dockerfile
+    # container_name: uwazi-elasticsearch
     volumes:
+      # - esdata01:/usr/share/elasticsearch/data
       - elasticsearch_data1:/usr/share/elasticsearch/data
-    # Close these ports. No unprotected elasticsearch should be published.
-    # ports:
-    #  - 9200:9200
+    ports:
+      - '9200:9200'
+    environment:
+      - bootstrap.memory_lock=true
+      - indices.query.bool.max_clause_count=2048
+      - discovery.type=single-node
+      - 'ES_JAVA_OPTS=-Xms2g -Xmx2g'
+      - cluster.routing.allocation.disk.threshold_enabled=false
 
   # dejavu "The Missing Web UI for Elasticsearch"
   # See https://github.com/appbaseio/dejavu

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,9 @@ services:
       - mongo
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.3
+    # image: docker.elastic.co/elasticsearch/elasticsearch:5.5.3
+    # Based on https://github.com/huridocs/uwazi/releases/tag/1.123.2 . Please update this part in future
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.6
     restart: unless-stopped
     command: elasticsearch -Expack.security.enabled=false -Ecluster.name=docker-cluster -Ehttp.port=9200 -Ehttp.cors.allow-origin="http://localhost:51000" -Ehttp.cors.enabled=true -Ehttp.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization -Ehttp.cors.allow-credentials=true
     environment:
@@ -51,7 +53,9 @@ services:
       - elasticsearch
 
   mongo:
-    image: mongo:3.4
+    # image: mongo:3.4
+    # Based on https://github.com/huridocs/uwazi/releases/tag/1.123.2 . Please update this part in future
+    image: mongo:4.2
     restart: unless-stopped
     volumes:
       # - ./data/mongo:/data/db

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,6 +21,8 @@ if [ "$IS_FIRST_RUN" = "true" ] ; then
     mongorestore -h "${DBHOST:-mongo}" "$DB_INITIALIZATION_PATH" --db="${DATABASE_NAME:-uwazi_development}"
 
     echo "uwazi-docker: Applyng yarn reindex. This will use data from MongoDB to feed Elastic Search"
+    # yarn reindex
+    yarn migrate
     yarn reindex
 
     echo "uwazi-docker: If no fatal errors occurred, you will not need to use this command again"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,16 +1,24 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "uwazi-docker: IS_FIRST_RUN: $IS_FIRST_RUN"
-DB_INITIALIZATION_PATH=/home/node/uwazi/blank_state/uwazi_development
+# DB_INITIALIZATION_PATH=/home/node/uwazi/blank_state/uwazi_development
+# DB_INITIALIZATION_PATH=/home/node/uwazi/dump/uwazi_development
+DB_INITIALIZATION_PATH=/home/node/uwazi/database/blank_state/uwazi_development
+
+set -x
+ls -lha /home/node/uwazi/
+# ls -lha /home/node/uwazi/dump
+
 
 if [ "$IS_FIRST_RUN" = "true" ] ; then
     echo "uwazi-docker: Enviroment variable IS_FIRST_RUN is true. Assuming need to install database from blank state"
 
-    echo "\n\nuwazi-docker: Deleting ${DBHOST:-mongo} ${DATABASE_NAME:-uwazi_development} MongoDB database"
-    mongo -host ${DBHOST:-mongo} ${DATABASE_NAME:-uwazi_development} --eval "db.dropDatabase()"
+    echo "uwazi-docker: Deleting ${DBHOST:-mongo} ${DATABASE_NAME:-uwazi_development} MongoDB database"
+    # mongo -host ${DBHOST:-mongo} ${DATABASE_NAME:-uwazi_development} --eval "db.dropDatabase()"
+    mongosh -host "${DBHOST:-mongo}" "${DATABASE_NAME:-uwazi_development}" --eval "db.dropDatabase()"
 
-    echo "\n\nuwazi-docker: Importing $DB_INITIALIZATION_PATH to ${DBHOST:-mongo} ${DATABASE_NAME:-uwazi_development} MongoDB database"
-    mongorestore -h ${DBHOST:-mongo} $DB_INITIALIZATION_PATH --db=${DATABASE_NAME:-uwazi_development}
+    echo "uwazi-docker: Importing $DB_INITIALIZATION_PATH to ${DBHOST:-mongo} ${DATABASE_NAME:-uwazi_development} MongoDB database"
+    mongorestore -h "${DBHOST:-mongo}" "$DB_INITIALIZATION_PATH" --db="${DATABASE_NAME:-uwazi_development}"
 
     echo "uwazi-docker: Applyng yarn reindex. This will use data from MongoDB to feed Elastic Search"
     yarn reindex

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
+DB_INITIALIZATION_PATH="${DB_INITIALIZATION_PATH:-"/home/node/uwazi/dump/uwazi_development"}"
 
+echo "uwazi-docker: UWAZI_GIT_RELEASE_REF: $UWAZI_GIT_RELEASE_REF"
 echo "uwazi-docker: IS_FIRST_RUN: $IS_FIRST_RUN"
+echo "uwazi-docker: RUN_YARN_MIGRATE_REINDEX: $RUN_YARN_MIGRATE_REINDEX"
+echo "uwazi-docker: DB_INITIALIZATION_PATH: $DB_INITIALIZATION_PATH"
 # DB_INITIALIZATION_PATH=/home/node/uwazi/blank_state/uwazi_development
-# DB_INITIALIZATION_PATH=/home/node/uwazi/dump/uwazi_development
-DB_INITIALIZATION_PATH=/home/node/uwazi/database/blank_state/uwazi_development
 
-set -x
-ls -lha /home/node/uwazi/
+# set -x
+# ls -lha /home/node/uwazi/
 # ls -lha /home/node/uwazi/dump
-
 
 if [ "$IS_FIRST_RUN" = "true" ] ; then
     echo "uwazi-docker: Enviroment variable IS_FIRST_RUN is true. Assuming need to install database from blank state"
@@ -25,10 +26,19 @@ if [ "$IS_FIRST_RUN" = "true" ] ; then
     yarn migrate
     yarn reindex
 
-    echo "uwazi-docker: If no fatal errors occurred, you will not need to use this command again"
+    echo "uwazi-docker: If no fatal errors occurred, you will never need to use this command again"
+    exit 0
+
+elif [ "$RUN_YARN_MIGRATE_REINDEX" = "true" ] ; then
+    echo "uwazi-docker: Applyng yarn reindex. This will use data from MongoDB to feed Elastic Search"
+    yarn migrate
+    yarn reindex
+
+    echo "uwazi-docker: If no fatal errors occurred, you will not need to use this command again unless data needs update to run with newer Uwazi or database version"
     exit 0
 else
-    echo "uwazi-docker: Enviroment variable IS_FIRST_RUN is not true. Assume MongoDB and Elastic Search provide already are intialized"
+    echo "uwazi-docker: Enviroment variable IS_FIRST_RUN/RUN_YARN_MIGRATE_REINDEX are not true."
+    echo "uwazi-docker: Assume MongoDB and Elastic Search provide already are intialized."
     echo "uwazi-docker: [protip] is possible to initialize (or reset o initial state) MongoDB and Elastic Search with enviroment variable IS_FIRST_RUN=true"
 fi
 

--- a/elastic-icu-7.17.6.Dockerfile
+++ b/elastic-icu-7.17.6.Dockerfile
@@ -1,0 +1,2 @@
+FROM elasticsearch:7.17.6
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu

--- a/requirements.md
+++ b/requirements.md
@@ -19,4 +19,4 @@ TODO: write about (fititnt, 2018-04-18 04:47 BRT)
 
 ### Docker
 [See updated instructions about how to install Docker Engine on Windows, Mac and Linux](https://docs.docker.com/compose/install/).
-Docker docker-compose is already installed.
+Docker docker compose is already installed.

--- a/uninstall.md
+++ b/uninstall.md
@@ -4,11 +4,11 @@ These commands explain how to uninstall uwazi-docker.
 
 ## Uninstall
 
-Use [docker-compose down](https://docs.docker.com/compose/reference/down/) to
+Use [docker compose down](https://docs.docker.com/compose/reference/down/) to
 remove the containers and networks created by uwazi-docker. This will not
 delete the data created.
 
-`docker-compose down # clean only containers and networks`
+`docker compose down # clean only containers and networks`
 
 ## Complete Uninstall
 
@@ -20,6 +20,6 @@ more the uwazi-docker or want a really full reinstall (e.g. is debugging).
 
 ```bash
 
-# Remove containers, networks and volumes created by uwazi-docker docker-compose up
-docker-compose down -v --rmi all --remove-orphans # WARNING: Purge everything, even data
+# Remove containers, networks and volumes created by uwazi-docker docker compose up
+docker compose down -v --rmi all --remove-orphans # WARNING: Purge everything, even data
 ```

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -3,8 +3,8 @@
 to a new one of Uwazi software.** Tip: the most important parts are MongoDB
 database and the uploaded_documents
 
-At the moment, uwazi-docker has commands that facilitate the first installation
-of the software, but upgrades from an old version of uwazi to a new one that
+<s>At the moment, uwazi-docker has commands that facilitate the first installation
+of the software, but</s> upgrades from an old version of uwazi to a new one that
 involve updating the database **require following official uwazi documentation**.
 
 - See: Upgrading Uwazi and data migrations at <https://github.com/huridocs/uwazi#upgrading-uwazi-and-data-migrations>.
@@ -13,3 +13,25 @@ Tip: see docker exec documentation at <https://docs.docker.com/engine/reference/
 to undestand how to run commands inside the container that runs the uwazi and
 run the commands that both update database and documents from older to the
 new version.
+
+#### `yarn migrate` and `yarn reindex`
+
+At installation step the `yarn migrate` and `yarn reindex` are always executed,
+however the database will be erased to a blank state.
+However, if for some you already have real data and not major database upgrade,
+in which MongoDB and ElasticSearch might need some minor custom steps outside of Uwazi control,
+this command will run once only the `yarn migrate` and `yarn reindex`.
+
+```bash
+docker compose run -e RUN_YARN_MIGRATE_REINDEX=true --rm uwazi
+```
+
+Just to be sure, if working with real data, **please backup the volumes first**.
+
+#### Major upgrade of MongoDB
+Please check MongoDB documentation.
+
+Please also open an issue on this repository if the way uwazi-docker run with newer MongoDB need changes. This was the case with last MongoDB upgrade (need some googling to replace the parameters, not hard).
+
+#### Major upgrade of ElasticSearch
+Please check ElasticSearch documentation and report issues here.


### PR DESCRIPTION
- Fixes the _Unmaintained deb package list, not starting #45_
- Defaults to `production` tag, instead of a fixed release, see https://github.com/huridocs/uwazi/tree/production
- Changes on documentation


Edit: based on initial report by  @mayeulk on _Unmaintained deb package list, not starting #45_